### PR TITLE
fix: replaced Makefile deploy with script deploy

### DIFF
--- a/krateo-composable-finops/assets/database-input.sh
+++ b/krateo-composable-finops/assets/database-input.sh
@@ -16,7 +16,7 @@ printf "apiVersion: finops.krateo.io/v1
 kind: DatabaseConfig
 metadata:
   name: finops-tutorial-config
-  namespace: default
+  namespace: finops
 spec:
   host: %s
   token: %s

--- a/krateo-composable-finops/assets/mock-webserver.yaml
+++ b/krateo-composable-finops/assets/mock-webserver.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: webservice-api-mock-deployment
+  namespace: finops
   labels:
     app: webservice-api-mock
 spec:
@@ -25,6 +26,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: webservice-api-mock-service
+  namespace: finops
 spec:
   selector:
     app: webservice-api-mock

--- a/krateo-composable-finops/step1/text.md
+++ b/krateo-composable-finops/step1/text.md
@@ -10,7 +10,7 @@ cd finops-operator-exporter
 Deploy the operator:
 IMG is the image of the operator. REPO indicates where to get the exporter/scraper images.
 ```plain
-make deploy IMG=ghcr.io/krateoplatformops/finops-operator-exporter:latest REPO=ghcr.io/krateoplatformops
+IMG=ghcr.io/krateoplatformops/finops-operator-exporter:latest REPO=ghcr.io/krateoplatformops ./scripts/deploy.sh
 ```{{exec}}
 
 Let's wait for the deployment to be available

--- a/krateo-composable-finops/step1/verify.sh
+++ b/krateo-composable-finops/step1/verify.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl wait deployment operator-exporter-controller-manager --for condition=Available=True --timeout=300s --namespace operator-exporter-system
+kubectl wait deployment operator-exporter-controller-manager --for condition=Available=True --timeout=300s --namespace finops

--- a/krateo-composable-finops/step2/text.md
+++ b/krateo-composable-finops/step2/text.md
@@ -11,7 +11,7 @@ cd finops-operator-scraper
 Deploy the operator:
 IMG is the image of the operator. REPO indicates where to get the exporter/scraper images.
 ```plain
-make deploy IMG=ghcr.io/krateoplatformops/finops-operator-scraper:latest REPO=ghcr.io/krateoplatformops
+IMG=ghcr.io/krateoplatformops/finops-operator-scraper:latest REPO=ghcr.io/krateoplatformops ./scripts/deploy.sh
 ```{{exec}}
 
 Let's wait for the deployment to be available

--- a/krateo-composable-finops/step2/verify.sh
+++ b/krateo-composable-finops/step2/verify.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl wait deployment operator-scraper-controller-manager --for condition=Available=True --timeout=300s --namespace operator-scraper-system
+kubectl wait deployment operator-scraper-controller-manager --for condition=Available=True --timeout=300s --namespace finops

--- a/krateo-composable-finops/step3/text.md
+++ b/krateo-composable-finops/step3/text.md
@@ -11,7 +11,7 @@ cd finops-operator-focus
 Deploy the operator:
 IMG is the image of the operator. REPO indicates where to get the exporter/scraper images.
 ```plain
-make deploy IMG=ghcr.io/krateoplatformops/finops-operator-focus:latest REPO=ghcr.io/krateoplatformops
+IMG=ghcr.io/krateoplatformops/finops-operator-focus:latest REPO=ghcr.io/krateoplatformops ./scripts/deploy.sh
 ```{{exec}}
 
 Let's wait for the deployment to be available

--- a/krateo-composable-finops/step3/verify.sh
+++ b/krateo-composable-finops/step3/verify.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl wait deployment operator-focus-controller-manager --for condition=Available=True --timeout=300s --namespace operator-focus-system
+kubectl wait deployment operator-focus-controller-manager --for condition=Available=True --timeout=300s --namespace finops

--- a/krateo-composable-finops/step4/text.md
+++ b/krateo-composable-finops/step4/text.md
@@ -19,6 +19,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: operator-exporter
   name: # ExporterScraperConfig name
+  namespace: finops
 spec:
   exporterConfig: # same as krateoplatformops/finops-prometheus-exporter-generic
     name: #name of the exporter
@@ -45,6 +46,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: operator-exporter
   name: exporterscraperconfig-sample
+  namespace: finops
 spec:
   exporterConfig:
     name: azure

--- a/krateo-composable-finops/step5/text.md
+++ b/krateo-composable-finops/step5/text.md
@@ -19,6 +19,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: operator-focus
   name: focusconfig-sample2
+  namespace: finops
 spec:
   scraperConfig: # same fields as krateoplatformops/finops-prometheus-scraper-generic
     tableName: # tableName in the database to upload the data to
@@ -80,6 +81,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: operator-focus
   name: focusconfig-sample
+  namespace: finops
 spec:
   focusSpec:
     region: \"EU\"

--- a/krateo-composable-finops/step7/text.md
+++ b/krateo-composable-finops/step7/text.md
@@ -118,7 +118,7 @@ apiVersion: finops.krateo.io/v1
 kind: DatabaseConfig
 metadata:
   name: # config name
-  namespace: default
+  namespace: finops
 spec:
   host: # host name for the database
   token: # access token

--- a/krateo-composable-finops/step71/database.yaml
+++ b/krateo-composable-finops/step71/database.yaml
@@ -2,7 +2,7 @@ apiVersion: finops.krateo.io/v1
 kind: DatabaseConfig
 metadata:
   name: finops-tutorial-config
-  namespace: default
+  namespace: finops
 spec:
   host: adb.sdjakdsj21038.sadi
   token: 321783u21n8e71287321-3

--- a/krateo-composable-finops/step71/verify.sh
+++ b/krateo-composable-finops/step71/verify.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl get databaseConfig finops-tutorial-config
+kubectl get databaseConfig finops-tutorial-config --namespace finops

--- a/krateo-composable-finops/step8/text.md
+++ b/krateo-composable-finops/step8/text.md
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: operator-exporter
   name: exporterscraperconfig-sample
+  namespace: finops
 spec:
   exporterConfig:
     name: azure
@@ -47,6 +48,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: operator-exporter
   name: exporterscraperconfig-sample
+  namespace: finops
 spec:
   exporterConfig:
     name: azure
@@ -72,7 +74,7 @@ kubectl apply -f sample.yaml
 
 The upload may take some time. Check when it's terminated with:
 ```plain
-kubectl logs -f deployment/exporterscraperconfig-sample-scraper-deployment
+kubectl logs -n finops -f deployment/exporterscraperconfig-sample-scraper-deployment
 ```{{exec}}
 
 You can verify the data in the SQL warehouse with a simple select. Make sure to select the correct catalog or enter the full path in the table name.


### PR DESCRIPTION
This bug has been caused by an update to the Makefile in https://github.com/krateoplatformops/finops-operator-exporter/commit/e88adacd2f69b2ba554e0f49167137a3cb77acba.
The lab has been updated to use the scripts instead of the Makefile. This is a temporary solution until the repositories with the Helm chart are available.