### PR TITLE
Add web form login/password instructions at the end

### DIFF
--- a/krateo-v2-composable-portal/step2/text.md
+++ b/krateo-v2-composable-portal/step2/text.md
@@ -54,4 +54,4 @@ The authn response contains the kubeconfig for the user logged in.
 cat cyberjoker.kubeconfig | jq
 ```{{exec}}
 
-Let's open again [Krateo Portal]({{TRAFFIC_HOST1_30080}}) and check if there's a new authentication form available.
+Let's open again [Krateo Portal]({{TRAFFIC_HOST1_30080}}) and check if there's a new authentication form available. Login with username cyberjoker and password 123456.


### PR DESCRIPTION
Add web form login/password instructions at the end (reading too quick, I wrongly entered cyberjoker-password as pass instead of 123456 in the web form, and caused an unhandled error so I can't even logout or retry)